### PR TITLE
Feat auto_id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,14 @@ default = []
 async = []
 # The "serde" feature enables serialization and deserialization of the library's types.
 serde = ["dep:serde"]
+# This feature enables the automatic generation of unique identifiers for nodes.
+auto_id = ["dep:unique_id", "dep:lazy_static"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 thiserror = "1.0.61"
+unique_id = { version = "0.1.5", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0" }

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,50 @@ Add the following to your `Cargo.toml` file:
 tree-ds = "0.1"
 ```
 
+### Nodes
+
+The basic building block of the library is the `Node` struct. The `Node` struct
+is a generic struct that can hold any type of data. The `Node` struct can be created
+as follows:
+
+```rust,ignore
+use tree_ds::prelude::*;
+
+let node: Node<String, i32> = Node::new("Root Node".to_string(), Some(100));
+``` 
+
+Optionally the crate provides an `auto_id` feature to automatically generate an Id
+for the node. This is useful when you are not concerned with the Id of the node and
+you want to avoid the overhead of managing the Ids. To enable the `auto_id`
+feature, add the following to your `Cargo.toml` file:
+
+```toml copy
+[dependencies]
+tree-ds = { version = "0.1", features = ["auto_id"] }
+```
+
+Then you can create a node as follows:
+
+```rust,ignore
+use tree_ds::prelude::*;
+
+// Not that in this case, the `Q` type parameter should be of type `i32` or any other type that implements the `From<i32>` trait.
+let node: Node<i32, &str> = Node::new_with_auto_id(Some("Some Node Value"));
+```
+
+### Trees
+
+The `Tree` struct is the main struct that is used to represent a tree. The `Tree`
+struct is generic over the type of data that the nodes in the tree hold. The `Tree`
+struct can be created as follows:
+
+```rust,ignore
+use tree_ds::prelude::*;
+
+let mut tree: Tree<String, i32> = Tree::new(Some("The Tree Name"));
+// Proceed to build the tree by adding nodes to it.
+```
+
 A crude example of how to use the library is shown below:
 
 ```rust
@@ -109,7 +153,7 @@ Equity: 3000
     └── Equity Mutual Funds: 500
 ```
 
-## Traversal
+#### Traversal
 
 You can traverse the tree using the `traverse` method. The `traverse` method
 returns an iterator that allows you to traverse the tree in any order you want.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 //! # Tree-DS
 //! A simple tree data structure implementation in Rust.
 //!
-//! ## Cargo Features
-//! - `default`: By default the library is synchronous.
-//! - `async`: Enables support for async operations on the tree.
-//! - `serde`: Enables serialization and deserialization of the tree.
+//! The tree data structure is a hierarchical data structure that consists of nodes connected by
+//! edges. Each node in the tree can have zero or more children nodes. The tree data structure
+//! is used in various applications, such as file systems, computer science, and biology.
 //!
 //! ## Usage
 //!
@@ -19,6 +18,31 @@
 //! let child_3 = tree.add_node(Node::new(4, Some(5)), Some(&child_2)).unwrap();
 //! let sub_tree = tree.get_subtree(&child_2, None);
 //!
+//! ```
+//!
+//! ## Nodes
+//! A Node is the building blocks of the tree data structure. Each node in the tree can have a value
+//! and a unique ID. The value can be of any type that implements the `Eq`, `PartialEq` and `Clone`
+//! traits.
+//!
+//! By default, the tree requires you to provide unique IDs for the nodes. This node Ids can be of
+//! any type that implements the `Eq` and `Clone` traits.
+//!
+//! ```rust
+//! use tree_ds::prelude::*;
+//!
+//! let node = Node::new(1, Some(2));
+//! ```
+//! However, you can enable the `auto_id` feature to generate IDs automatically. This is useful when
+//! you want to create a node without specifying the ID. For a node to be created with an auto-generated
+//! ID, the `Q` type must implement the `From<i32>` trait.
+//!
+//! ```rust
+//! use tree_ds::prelude::*;
+//!
+//! let node = Node::<i32, &str>::new_with_auto_id(Some("Harry Doe"));
+//! let node_2 = Node::<i32, &str>::new_with_auto_id(Some("Jane Doe"));
+//! assert_ne!(node.get_node_id(), node_2.get_node_id());
 //! ```
 //!
 //! ## Traversal
@@ -67,7 +91,12 @@
 //!    └── Node 3: 5
 //!        └── Node 4: 6
 //! ```
-
+//!
+//! ## Cargo Features
+//! - `default`: By default the library is synchronous, and you need to provide ids for the nodes.
+//! - `async`: Enables support for async operations on the tree.
+//! - `serde`: Enables serialization and deserialization of the tree.
+//! - `auto_id`: Enables auto-generation of node IDs.
 mod error;
 mod node;
 mod tree;

--- a/src/node/auto_id.rs
+++ b/src/node/auto_id.rs
@@ -1,0 +1,80 @@
+use std::cell::RefCell;
+#[cfg(not(feature = "async"))]
+use std::rc::Rc;
+#[cfg(feature = "async")]
+use std::sync::Arc;
+
+use lazy_static::lazy_static;
+use unique_id::Generator;
+use unique_id::sequence::SequenceGenerator;
+
+use crate::node::{_Node, Node};
+
+lazy_static! {
+	static ref GENERATOR: SequenceGenerator = SequenceGenerator;
+}
+
+impl<Q, T> Node<Q, T>
+	where
+		Q: PartialEq + Eq + Clone + From<i32>,
+		T: PartialEq + Eq + Clone,
+{
+	/// Creates a new node with an auto-generated ID.
+	///
+	/// The ID is generated using a sequence generator, meaning that the ID is sequential and unique.
+	/// This is useful when you want to create a node without specifying the ID. For a node to be
+	/// created with an auto-generated ID, the `Q` type must implement the `From<i32>` trait.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The value to store in the node.
+	///
+	/// # Returns
+	///
+	/// A new node with an auto-generated ID.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// # use tree_ds::prelude::*;
+	///
+	/// let node = Node::<i32, &str>::new_with_auto_id(Some("Harry Doe"));
+	/// let node_2 = Node::<i32, &str>::new_with_auto_id(Some("Jane Doe"));
+	/// assert_ne!(node.get_node_id(), node_2.get_node_id());
+	/// ```
+	///
+	/// This is available only when the `auto_id` feature is enabled.
+	pub fn new_with_auto_id(value: Option<T>) -> Self {
+		#[cfg(not(feature = "async"))]
+		{
+			Self(Rc::new(RefCell::new(_Node {
+				node_id: Q::from(GENERATOR.next_id() as i32),
+				value,
+				children: vec![],
+				parent: None,
+			})))
+		}
+		#[cfg(feature = "async")]
+		{
+			Self(Arc::new(RefCell::new(_Node {
+				node_id: Q::from(GENERATOR.next_id() as i32),
+				value,
+				children: vec![],
+				parent: None,
+			})))
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_new_with_auto_id() {
+		let node = Node::<i32, &str>::new_with_auto_id(Some("Harry Doe"));
+		let node_2 = Node::<i32, &str>::new_with_auto_id(Some("Jane Doe"));
+		assert_eq!(node.get_value(), Some("Harry Doe"));
+		assert_ne!(node.get_node_id(), node_2.get_node_id());
+	}
+}

--- a/src/node/auto_id.rs
+++ b/src/node/auto_id.rs
@@ -70,8 +70,18 @@ impl<Q, T> Node<Q, T>
 mod tests {
 	use super::*;
 
+	#[cfg(not(feature = "async"))]
 	#[test]
 	fn test_new_with_auto_id() {
+		let node = Node::<i32, &str>::new_with_auto_id(Some("Harry Doe"));
+		let node_2 = Node::<i32, &str>::new_with_auto_id(Some("Jane Doe"));
+		assert_eq!(node.get_value(), Some("Harry Doe"));
+		assert_ne!(node.get_node_id(), node_2.get_node_id());
+	}
+
+	#[cfg(feature = "async")]
+	#[test]
+	fn test_new_with_auto_id_async() {
 		let node = Node::<i32, &str>::new_with_auto_id(Some("Harry Doe"));
 		let node_2 = Node::<i32, &str>::new_with_auto_id(Some("Jane Doe"));
 		assert_eq!(node.get_value(), Some("Harry Doe"));

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
 use serde::ser::SerializeStruct;
 
+#[cfg(feature = "auto_id")]
+mod auto_id;
+
 /// A node in a tree.
 ///
 /// This struct represents a node in a tree. The node has a unique id, a value, children and a parent. The unique id
@@ -104,46 +107,25 @@ impl<Q, T> Node<Q, T>
 	///
 	/// let node = Node::new(1, Some(2));
 	/// ```
-	#[cfg(not(feature = "async"))]
 	pub fn new(node_id: Q, value: Option<T>) -> Self {
-		Node(Rc::new(RefCell::new(_Node {
-			node_id,
-			value,
-			children: vec![],
-			parent: None,
-		})))
-	}
-
-	/// Create a new node.
-	///
-	/// This method creates a new node with the given node id and value. The node id is used to identify the node
-	/// and the value is the value of the node. The value can be used to store any data that you want to associate
-	/// with the node.
-	///
-	/// # Arguments
-	///
-	/// * `node_id` - The id of the node.
-	/// * `value` - The value of the node.
-	///
-	/// # Returns
-	///
-	/// A new node with the given node id and value.
-	///
-	/// # Example
-	///
-	/// ```rust
-	/// # use tree_ds::prelude::Node;
-	///
-	/// let node = Node::new(1, Some(2));
-	/// ```
-	#[cfg(feature = "async")]
-	pub fn new(node_id: Q, value: Option<T>) -> Self {
-		Node(Arc::new(RefCell::new(_Node {
-			node_id,
-			value,
-			children: vec![],
-			parent: None,
-		})))
+		#[cfg(not(feature = "async"))]
+		{
+			Node(Rc::new(RefCell::new(_Node {
+				node_id,
+				value,
+				children: vec![],
+				parent: None,
+			})))
+		}
+		#[cfg(feature = "async")]
+		{
+			Node(Arc::new(RefCell::new(_Node {
+				node_id,
+				value,
+				children: vec![],
+				parent: None,
+			})))
+		}
 	}
 
 	/// Add a child to the node.
@@ -403,7 +385,7 @@ impl<'de, Q, T> Deserialize<'de> for Node<Q, T>
 		let node: _Node<Q, T> = Deserialize::deserialize(deserializer)?;
 
 		#[cfg(not(feature = "async"))]
-		return Ok(crate::node::Node(Rc::new(RefCell::new(node))));
+		return Ok(Node(Rc::new(RefCell::new(node))));
 		#[cfg(feature = "async")]
 		return Ok(Node(Arc::new(RefCell::new(node))));
 	}


### PR DESCRIPTION
## Problem Statement
In some scenarios, we do not need to set the ids of nodes manually. Consider this:
- You need to create a huge tree and do not want the overhead of assigning and managing unique ids to nodes.
- The node Id is not really necessary in the type of data you are trying to model. For instance file system data.

In such scenarios, it would be nice to have some sort of auto node_id management.

## Fixes
This PR implements auto generated ids for nodes. This is implemented in a cargo feature flag; `auto_id`. This ensures that we still have the freedom to create custom ids but can in scenarios that we do not need the Id, it can be auto generated.

## Usage
Once the cargo feature is enabled, the user can use the `Node::new_with_auto_id()` function passing in the value only. The Id is automatically generated.